### PR TITLE
Use array in "write to files" test.

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ example in [example.c](https://github.com/mortie/snow/blob/master/example.c).
 			defer(remove("testfile"));
 			defer(fclose(f));
 
-			char *str = "hello there";
+			char str[] = "hello there";
 			asserteq(fwrite(str, 1, sizeof(str), f), sizeof(str));
 		});
 


### PR DESCRIPTION
The use of sizeof to get the size of a string pointed to by a char * is probably not what was intended. 
The test will report success, but the entire string will not be written. 
Need to either make str into a static array so that sizeof does the right thing, or use strlen to calculate its size.
Used the former in this commit.