### PR TITLE
Auto-run PoC

### DIFF
--- a/example.c
+++ b/example.c
@@ -1,6 +1,6 @@
 #include "snow/snow.h"
 #include <stdio.h>
-
+snow({
 describe(files, {
 	it("opens files", {
 		FILE *f = fopen("Makefile", "r");
@@ -60,7 +60,4 @@ describe(files, {
 		});
 	});
 });
-
-snow_main({
-	test_files();
 });

--- a/snow/snow.h
+++ b/snow/snow.h
@@ -375,7 +375,7 @@ static int __attribute__((unused)) _snow_assertneq_buf(
 	} while(0)
 
 #define describe(testname, ...) \
-	static void test_##testname() { \
+	void test_##testname() { \
 		_snow_num_defines += 1; \
 		char *_snow_name = #testname; \
 		int __attribute__((unused)) _snow_depth = 0; \
@@ -387,10 +387,15 @@ static int __attribute__((unused)) _snow_assertneq_buf(
 		_snow_print_done(); \
 		_snow_global_successes += _snow_successes; \
 		_snow_global_total += _snow_total; \
-	}
+	} \
+    described_functions[clause_counter++] = &test_##testname;
 
-#define snow_main(...) \
+
+#define snow(...) \
 	int main(int argc, char **argv) { \
+        int clause_counter = 0;\
+        void (*described_functions[512])();\
+        __VA_ARGS__ \
 		if (!isatty(1)) \
 			_snow_opt_color = 0; \
 		else if (getenv("NO_COLOR") != NULL) \
@@ -401,7 +406,9 @@ static int __attribute__((unused)) _snow_assertneq_buf(
 			else if (strcmp(argv[i], "--no-color") == 0) \
 				_snow_opt_color = 0; \
 		} \
-		__VA_ARGS__ \
+		for (int i = 0; i < clause_counter; i++) { \
+            described_functions[i](); \
+        }\
 		free(_snow_labels.labels); \
 		if (_snow_num_defines > 1) { \
 			if (_snow_opt_color) { \


### PR DESCRIPTION
Here's a quick hack to show that auto-running tests can be done in a safe manner. I've scrapped snow_main in favor of a snow-clause that contain the descriptions. (A suite?)

Gotchas:
* I exploited the fact that GCC allows nested functions, a feature that is sadly not supported in Clang.
* The way I've structured the hack means that a suite exists in one file and compiles to exactly one binary per suite.

Remaining Todo:
* Clean up the clause code to match the style of the project
* Realloc in favor of a static limit
* Print out the name of currently running suite?
* Reflect changes in README