### PR TITLE
fix asserts on ARM by making the _Generic selection more... generic

### DIFF
--- a/snow/snow.h
+++ b/snow/snow.h
@@ -1260,9 +1260,9 @@ static int _snow_assert_fake(int invert, ...) {
 	return -1;
 }
 
-// In mingw, size_t is compatible with unsigned int, and
+// In mingw and on ARM, size_t is compatible with unsigned int, and
 // ssize_t is compatible with int
-#ifdef __MINGW32__
+#if(__SIZEOF_SIZE_T__ == __SIZEOF_INT__)
 #define _snow_generic_assert(x) \
 	_Generic((x), \
 		float: _snow_assert_dbl, \


### PR DESCRIPTION
Currently Snow fails to build on armv7h, with the same issue as MinGW. Rather than a platform test, I use a test for the underlying issue of `sizeof(size_t) == sizeof(unsigned int)`. Since we're only targeting `GCC` and `clang`, we can use the `__SIZE_*__` macros for that.