### PR TITLE
Definable Default Arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,8 @@ snow_main();
   description.
 * **SNOW\_COLOR\_BOLD**: The escape sequence for bold text.
 * **SNOW\_COLOR\_RESET**: The escape sequence to reset formatting.
+* **SNOW\_DEFAULT\_ARGS**: A comma seperated list of strings to pass as
+  arguments to snow before the command-line arguments.
 
 ## Structure Macros
 

--- a/snow/snow.h
+++ b/snow/snow.h
@@ -836,6 +836,14 @@ static void _snow_usage(char *argv0) {
 		"    --gdb, -g:      Run the test suite on GDB, and break and re-run\n"
 		"                    test cases which fail.\n"
 		"                    Default: off.\n");
+    char *default_args[] = { "snow", SNOW_DEFAULT_ARGS };
+    if (sizeof(default_args) > sizeof(char *) * 1) {
+        _snow_print("\nCompiled with default arguments:");
+        for (int i = 0; i < sizeof(default_args)/sizeof(char *); ++i) {
+            _snow_print(" %s", default_args[i]);
+        }
+        _snow_print("\n");
+    }
 }
 
 /*

--- a/snow/snow.h
+++ b/snow/snow.h
@@ -793,8 +793,7 @@ static void _snow_after_each_end(void) {
  * Usage
  */
 __attribute__((unused))
-static void _snow_usage(char *argv0)
-{
+static void _snow_usage(char *argv0) {
 	_snow_print("Usage: %s [options]            Run all tests.\n", argv0);
 	_snow_print("       %s [options] <test>...  Run specific tests.\n", argv0);
 	_snow_print("       %s -v|--version         Print version and exit.\n", argv0);
@@ -843,8 +842,7 @@ static void _snow_usage(char *argv0)
  * Parse a single argument
  */
 __attribute__((unused))
-int _snow_parse_args(char **args, int num)
-{
+int _snow_parse_args(char **args, int num) {
 	int opts_done = 0;
 	for (int i = 1; i < num; ++i) {
 		char *arg = args[i];

--- a/snow/snow.h
+++ b/snow/snow.h
@@ -915,11 +915,11 @@ static int snow_main_function(int argc, char **argv) {
 	 */
 	int res;
 	char *default_args[] = { "snow", SNOW_DEFAULT_ARGS };
-	res = _snow_parse_args(argv, argc);
+	res = _snow_parse_args(default_args, sizeof(default_args)/sizeof(char *));
 	if (res != 0)
 		return res;
 
-	res = _snow_parse_args(default_args, sizeof(default_args)/sizeof(char *));
+	res = _snow_parse_args(argv, argc);
 	if (res != 0)
 		return res;
 

--- a/snow/snow.h
+++ b/snow/snow.h
@@ -839,7 +839,7 @@ static void _snow_usage(char *argv0) {
     char *default_args[] = { "snow", SNOW_DEFAULT_ARGS };
     if (sizeof(default_args) > sizeof(char *) * 1) {
         _snow_print("\nCompiled with default arguments:");
-        for (int i = 0; i < sizeof(default_args)/sizeof(char *); ++i) {
+        for (int i = 1; i < sizeof(default_args)/sizeof(char *); ++i) {
             _snow_print(" %s", default_args[i]);
         }
         _snow_print("\n");
@@ -850,7 +850,7 @@ static void _snow_usage(char *argv0) {
  * Parse a single argument
  */
 __attribute__((unused))
-int _snow_parse_args(char **args, int num) {
+static int _snow_parse_args(char **args, int num) {
 	int opts_done = 0;
 	for (int i = 1; i < num; ++i) {
 		char *arg = args[i];

--- a/snow/snow.h
+++ b/snow/snow.h
@@ -130,6 +130,10 @@
 #define SNOW_COLOR_DESC SNOW_COLOR_BOLD "\033[33m"
 #endif
 
+#ifndef SNOW_DEFAULT_ARGS
+#define SNOW_DEFAULT_ARGS
+#endif
+
 /*
  * Array
  */
@@ -836,24 +840,14 @@ static void _snow_usage(char *argv0)
 }
 
 /*
- * The main function, which runs all top-level describes
- * and cleans up.
+ * Parse a single argument
  */
 __attribute__((unused))
-static int snow_main_function(int argc, char **argv) {
-
-	// There might be no tests, so we should init _snow here too
-	if (!_snow_inited)
-		_snow_init();
-
-	/*
-	 * Parse arguments
-	 */
-
+int _snow_parse_args(char **args, int num)
+{
 	int opts_done = 0;
-	for (int i = 1; i < argc; ++i) {
-		char *arg = argv[i];
-
+	for (int i = 1; i < num; ++i) {
+		char *arg = args[i];
 		if (opts_done || arg[0] != '-') {
 			_snow_arr_push(&_snow.desc_patterns, &arg);
 			continue;
@@ -884,12 +878,12 @@ static int snow_main_function(int argc, char **argv) {
 					break;
 				}
 
-				if (i + 1 >= argc ) {
+				if (i + 1 >= num) {
 					fprintf(stderr, "%s: Argument expected.", arg);
 					return EXIT_FAILURE;
 				}
 
-				opt->strval = argv[++i];
+				opt->strval = args[++i];
 			}
 
 			break;
@@ -900,6 +894,34 @@ static int snow_main_function(int argc, char **argv) {
 			return EXIT_FAILURE;
 		}
 	}
+
+	return 0;
+}
+
+/*
+ * The main function, which runs all top-level describes
+ * and cleans up.
+ */
+
+__attribute__((unused))
+static int snow_main_function(int argc, char **argv) {
+
+	// There might be no tests, so we should init _snow here too
+	if (!_snow_inited)
+		_snow_init();
+
+	/*
+	 * Parse arguments
+	 */
+	int res;
+	char *default_args[] = { "snow", SNOW_DEFAULT_ARGS };
+	res = _snow_parse_args(argv, argc);
+	if (res != 0)
+		return res;
+
+	res = _snow_parse_args(default_args, sizeof(default_args)/sizeof(char *));
+	if (res != 0)
+		return res;
 
 	/*
 	 * Respond to args


### PR DESCRIPTION
This pull request provides a mechanism for modifying the default values of snow arguments by specifying a series of default arguments in a define.

The arguments are simply comma-separated strings, i.e.
#define SNOW_DEFAULT_ARGS "--no-maybes", "--cr"

When snow is run, the arguments are simply prepended to the command-line arguments. This works for arguments that can be overriden by later instances of themselves.

This is a simple mechanism for users of snow to specify default values for the snow arguments, without incurring any major changes to snow, and in a very intuitive way for users.

The motivation for this was a desire to direct logging output of a program to stdout during tests, which did not interact well with the --maybes option. This change allows for this issue to be circumvented using #define SNOW_DEFAULT_ARGS "--no-maybes".