### PR TITLE
Bugfix: Fix optimization on GCC

### DIFF
--- a/snow/snow.h
+++ b/snow/snow.h
@@ -102,6 +102,9 @@
 // This is necessary unless I can avoid using `typeof`
 #pragma GCC diagnostic ignored "-Wlanguage-extension-token"
 
+// This is required to calm GCC about __attribute__((optnone))
+#pragma GCC diagnostic ignored "-Wattributes"
+
 /*
  * Colors
  */
@@ -1155,6 +1158,7 @@ cleanup:
 		_snow_arr_push(&_snow.desc_funcs, &df); \
 	} \
 	__attribute__((optnone)) \
+	__attribute__((optimize(0))) \
 	static void snow_test_##name()
 
 #define subdesc(name) \


### PR DESCRIPTION
The `__attribute__((optnone))` attribute appears to be clang-specific. GCC does not respect this argument, and so if compiled with optimizations, the use of setjmp() in snow causes variables to contain undefined values.

A small example:

The file `test.c`
```

snow_main();

describe(test)
{
    int x = 0;

    before_each() { ++x; }

    it ("1") { asserteq(x, 1); }
    it ("2") { asserteq(x, 2); }
    it ("3") { asserteq(x, 3); }
}
```

Run the following commands:

```
clang -O3 -DSNOW_ENABLED test.c; ./a.out     # succeeds
gcc -O3 -DSNOW_ENABLED test.c; ./a.out       # fails (!)
```

With this patch, both commands succeed. As yet untested on Windows.