### PR TITLE
Fix: Print correct file/line when a subroutine contains an assert.

### DIFF
--- a/test/.gitignore
+++ b/test/.gitignore
@@ -8,4 +8,6 @@ cases/tests
 cases/tests.exe
 cases/around
 cases/around.exe
+cases/misc
+cases/misc.exe
 snow

--- a/test/cases/misc.c
+++ b/test/cases/misc.c
@@ -1,0 +1,22 @@
+#include <snow/snow.h>
+
+static inline int asserteq_call(int a, int b)
+{
+	asserteq(a, b);
+	return a + b;
+}
+
+static inline int fail_call()
+{
+	fail("It has gone wrong :(");
+	return 0;
+}
+
+describe(fail_in_call) {
+	test("asserteq pass") { asserteq(asserteq_call(1, 1), 2); }
+	test("asserteq fail outer") { asserteq(asserteq_call(1, 1), 3); }
+	test("asserteq fail inner") { asserteq(asserteq_call(1, 2), 3); }
+	test("fail inner") { asserteq(fail_call(), 0); }
+}
+
+snow_main();

--- a/test/expected/misc-fail-in-call
+++ b/test/expected/misc-fail-in-call
@@ -1,0 +1,14 @@
+
+Testing fail_in_call:
+✓ Success: asserteq pass (1.00s)
+✕ Failed:  asserteq fail outer:
+    (int) Expected asserteq_call(1, 1) to equal 3, but got 2.
+    in cases/misc.c:17(fail_in_call)
+✕ Failed:  asserteq fail inner:
+    (int) Expected a to equal b, but got 1.
+    in cases/misc.c:5(fail_in_call)
+✕ Failed:  fail inner:
+    It has gone wrong :(
+    in cases/misc.c:11(fail_in_call)
+fail_in_call: Passed 1/4 tests. (6.00s)
+

--- a/test/test.c
+++ b/test/test.c
@@ -323,5 +323,11 @@ describe(around) {
 	}
 }
 
+describe(misc) {
+	it("can fail in a subroutine call") {
+		assert(compareOutput("./cases/misc fail_in_call", "misc-fail-in-call"));
+	}
+}
+
 snow_main();
 #endif


### PR DESCRIPTION
Tests such as asserts were implemented as macros containing two parts:
```
    snow_fail_update(); // Update the globally stored file and line number
    _asserteq(thing 1, thing 2); // Perform a check
```

This falls down if "thing 1" or "thing 2" contain assertions themselves, which themselves update the globally stored file and line number. If the outer assertion then fails, it reports the wrong file and line number.

To fix this, add a struct _snow_explanation that is created in assertion macros, and is used to update the global file and line number only once the actual failure is triggered.